### PR TITLE
Omit gitHash if UNKNOWN

### DIFF
--- a/src/Options/Applicative/Simple.hs
+++ b/src/Options/Applicative/Simple.hs
@@ -89,13 +89,18 @@ simpleOptions versionString h pd globalParser commandParser =
 -- @$(simpleVersion …)@ @::@ 'String'
 simpleVersion :: Version -> Q Exp
 simpleVersion version =
-  [|concat ["Version "
+  [|concat (["Version "
            ,$(TH.lift $ showVersion version)
-           ,", Git revision "
-           ,$gitHash
-           ,if $gitDirty
-               then " (dirty)"
-               else ""]|]
+           ] ++
+           if $gitHash == "UNKNOWN"
+             then []
+             else
+               [", Git revision "
+               ,$gitHash
+               ,if $gitDirty
+                   then " (dirty)"
+                   else ""
+               ])|]
 
 -- | Add a command to the options dispatcher.
 addCommand :: String   -- ^ command string


### PR DESCRIPTION
I find it annoying when using an executable not built from a git repository (e.g. cabal install from hackage) for it to print "git revision UNKNOWN". It's just noise; better to omit it.
