### PR TITLE
Add source-repository section in cabal file.

### DIFF
--- a/optparse-simple.cabal
+++ b/optparse-simple.cabal
@@ -32,3 +32,7 @@ test-suite test
                    , bytestring -any
   hs-source-dirs:    test
   ghc-options:       -Wall -O2
+
+source-repository head
+  type:              git
+  location:          https://github.com/fpco/optparse-simple


### PR DESCRIPTION
I was trying to find the source for this so I could copy the `simpleVersion` function into another application. Turns out, there's no link to this repository on Hackage, so I thought I'd add one.
