### PR TITLE
Update LTS and use githash instead of gitrev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
 
 # The different configurations we want to test. We have BUILD=cabal which uses
 # cabal-install, and BUILD=stack which uses Stack. More documentation on each
@@ -44,21 +45,27 @@ matrix:
   #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #  compiler: ": #GHC 7.4.2"
   #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.6.3"
+  #   addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.8.4"
+  #   addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  # - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #   compiler: ": #GHC 7.10.3"
+    # addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.2.2"
     addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.4.4 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.4.4"
+    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.6.3 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.3"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
@@ -72,24 +79,36 @@ matrix:
     compiler: ": #stack default"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
-    addons: {apt: {packages: [libgmp-dev]}}
+  # - env: BUILD=stack ARGS="--resolver lts-2"
+  #   compiler: ": #stack 7.8.4"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2"
-    addons: {apt: {packages: [libgmp-dev]}}
+  # - env: BUILD=stack ARGS="--resolver lts-3"
+  #   compiler: ": #stack 7.10.2"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3"
-    addons: {apt: {packages: [libgmp-dev]}}
+  # - env: BUILD=stack ARGS="--resolver lts-6"
+  #   compiler: ": #stack 7.10.3"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1"
-    addons: {apt: {packages: [libgmp-dev]}}
+  # - env: BUILD=stack ARGS="--resolver lts-7"
+  #   compiler: ": #stack 8.0.1"
+  #   addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-9"
     compiler: ": #stack 8.0.2"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-11"
+    compiler: ": #stack 8.2.2"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-12"
+    compiler: ": #stack 8.4.4"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-13"
+    compiler: ": #stack 8.6.3"
     addons: {apt: {packages: [libgmp-dev]}}
 
   # Nightly builds are allowed to fail
@@ -107,20 +126,32 @@ matrix:
   #  compiler: ": #stack 7.8.4 osx"
   #  os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2 osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver lts-3"
+  #   compiler: ": #stack 7.10.2 osx"
+  #   os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3 osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver lts-6"
+  #   compiler: ": #stack 7.10.3 osx"
+  #   os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1 osx"
-    os: osx
+  # - env: BUILD=stack ARGS="--resolver lts-7"
+  #   compiler: ": #stack 8.0.1 osx"
+  #   os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-9"
     compiler: ": #stack 8.0.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-11"
+    compiler: ": #stack 8.2.2 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-12"
+    compiler: ": #stack 8.4.4 osx"
+    os: osx
+
+  - env: BUILD=stack ARGS="--resolver lts-13"
+    compiler: ": #stack 8.6.3 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"
@@ -154,11 +185,6 @@ before_install:
   mkdir -p $HOME/.cabal
   echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
   echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
-
-  if [ "$CABALVER" != "1.16" ]
-  then
-    echo 'jobs: $ncpus' >> $HOME/.cabal/config
-  fi
 
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* Switch dependency `gitrev` to `githash`
+
 ## 0.1.0
 
 * Migrate from `EitherT` to `ExceptT`

--- a/example/Simple.hs
+++ b/example/Simple.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Main (main) where
+
+import           Options.Applicative.Simple (simpleVersion)
+import qualified Paths_optparse_simple as Meta
+
+main :: IO ()
+main = putStrLn $(simpleVersion Meta.version)

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ library:
   dependencies:
   - template-haskell
   - optparse-applicative
-  - gitrev
+  - githash >= 0.1.3
   - transformers >=0.4
 tests:
   test:

--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,7 @@ extra-source-files:
 - ChangeLog.md
 
 dependencies:
-- base >=4 && <5
+- base >= 4.9.1 && <5
 
 library:
   source-dirs: src/
@@ -22,8 +22,11 @@ library:
   dependencies:
   - template-haskell
   - optparse-applicative
-  - githash >= 0.1.3
-  - transformers >=0.4
+  - githash >= 0.1.3.0
+  - transformers >= 0.4
+  when:
+    - condition: impl (ghc < 8.0)
+      dependencies: semigroups == 0.18.*
 tests:
   test:
     main: Main.hs

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,13 @@ library:
   when:
     - condition: impl (ghc < 8.0)
       dependencies: semigroups == 0.18.*
+
+executables:
+  simple:
+    main: example/Simple.hs
+    dependencies:
+    - optparse-simple
+
 tests:
   test:
     main: Main.hs

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        optparse-simple
-version:     0.1.0
+version:     0.1.1
 synopsis:    Simple interface to optparse-applicative
 description: Please see the README at <https://www.stackage.org/package/optparse-simple>
 category:    Options

--- a/src/Options/Applicative/Simple.hs
+++ b/src/Options/Applicative/Simple.hs
@@ -88,13 +88,10 @@ simpleVersion version =
            ] ++
            case giResult of
              Left _ -> []
-             Right gi ->
-               if giHash gi == "UNKNOWN"
-               then []
-               else [ ", Git revision "
-                    , giHash gi
-                    , if giDirty gi then " (dirty)" else ""
-                    ]
+             Right gi -> [ ", Git revision "
+                         , giHash gi
+                         , if giDirty gi then " (dirty)" else ""
+                         ]
            )|]
   where
     giResult = $$tGitInfoCwdTry

--- a/src/Options/Applicative/Simple.hs
+++ b/src/Options/Applicative/Simple.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
 
 -- | Simple interface to program arguments.
 --
@@ -41,6 +42,9 @@ module Options.Applicative.Simple
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Writer
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup
+#endif
 import           Data.Version
 import           GitHash (giDirty, giHash, tGitInfoCwdTry)
 import           Language.Haskell.TH (Q,Exp)

--- a/src/Options/Applicative/Simple.hs
+++ b/src/Options/Applicative/Simple.hs
@@ -41,7 +41,6 @@ module Options.Applicative.Simple
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Writer
-import           Data.Monoid
 import           Data.Version
 import           Development.GitRev (gitDirty, gitHash)
 import           Language.Haskell.TH (Q,Exp)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-9.9
+resolver: lts-13.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
-resolver: lts-13.0
+resolver: lts-13.0 # ghc-8.6.3
+extra-deps:
+- githash-0.1.3.0


### PR DESCRIPTION
Done:

- Use latest resolver (lts-13.0)
- Use `githash` instead of `gitrev`
- Update `travis.yml`
  - Drop older ghc (ghc-7.6.3, ghc-7.8.4, ghc-7.10.3)
  - Support newer ghc (ghc-8.4.4, ghc-8.6.3)